### PR TITLE
Propagate whiteboard field when backporting

### DIFF
--- a/rhcosbot.py
+++ b/rhcosbot.py
@@ -178,7 +178,6 @@ class Bugzilla:
         'cf_verified',
         'component',
         'keywords',
-        'whiteboard',
         'product',
         'summary',
         'status',
@@ -591,6 +590,7 @@ class CommandHandler(metaclass=Registry):
             'groups',
             'severity',
             'version',
+            'whiteboard'
         ])
         if bug.severity == 'unspecified':
             # Eric-Paris-bot will unset the target version without a severity


### PR DESCRIPTION
Context: https://coreos.slack.com/archives/C01BCJY8XRD/p1635269245038400
ART and ProdSec would like to propagate the whiteboard field in bugs when backporting, so our logic is reliably able to classify bugs as rpm/image bugs