### PR TITLE
rhcosbot.py: also print errors sent to administrator

### DIFF
--- a/rhcosbot.py
+++ b/rhcosbot.py
@@ -502,6 +502,8 @@ def report_errors(f):
                 client = WebClient(token=config.slack_token)
                 channel = client.conversations_open(users=[config.error_notification])['channel']['id']
                 client.chat_postMessage(channel=channel, text=message)
+                # but always also print to the logs
+                print(message)
             except Exception:
                 traceback.print_exc()
         try:


### PR DESCRIPTION
The canonical place to look for error messages when something goes wrong is the pod logs. Let's just have it always print them there too.